### PR TITLE
Parameterize flow log activator reserved concurrent executions

### DIFF
--- a/cfct/templates/vpc_flowlog_automation_in_hub.template
+++ b/cfct/templates/vpc_flowlog_automation_in_hub.template
@@ -83,6 +83,10 @@ Parameters:
     - REJECT
     - ALL
     - DISABLE
+  FlowLogActivatorConcurrency:
+    Type: String
+    Default: 500
+    Description: 'The Reserved Concurrent Executions setting for the Flow Log Activator function.'
 
 Conditions:
 
@@ -223,7 +227,7 @@ Resources:
       Runtime: "python3.7"
       MemorySize: 128
       Timeout: 300
-      ReservedConcurrentExecutions: 500
+      ReservedConcurrentExecutions: !Ref FlowLogActivatorConcurrency
       Environment:
         Variables:
             assume_role: !FindInMap [LambdaVariable,Role, Spoke]


### PR DESCRIPTION
*Issue #, if available:*

#23 

*Description of changes:*

This will allow one to define a different amount of reserved concurrent executions for the flow log activator lambda function due to service quota limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
