### PR TITLE
Fix: Python Version and Multi Region Spoke accounts

### DIFF
--- a/cfct/manifest.yaml
+++ b/cfct/manifest.yaml
@@ -42,7 +42,7 @@ resources:
       - name: /org/sharedservice/networking/vpcflowlogsbucket
         value: $[output_oBucketName]
     regions:
-      - ap-southeast-2
+      - ap-southeast-2 # choose your control tower master region
 
   - name: VPCFlowLogsMgmtRole
     resource_file: templates/vpc_flowlog_mgmt.template
@@ -53,14 +53,14 @@ resources:
       - parameter_key: "EventBusDestinationAccount" # Typiclly this will be the NetworkHub account
         parameter_value: "<REPLACE ME>"
 
-      - parameter_key: "BaselineCloudTrailStackArn" # Copy this this from mgmt account in cloudformation stacksets for AWSControlTowerBP-BASELINE-CLOUDTRAIL
+      - parameter_key: "BaselineConfigStackArn" # Copy this this from mgmt account in cloudformation stacksets for AWSControlTowerBP-BASELINE-CLOUDTRAIL
         parameter_value: "<REPLACE ME>"
     deploy_method: stack_set
     deployment_targets:
       accounts:
-        - Management
+        - Management # Control Tower Management Account
     regions:
-      - ap-southeast-2
+      - ap-southeast-2 # choose your control tower master region
 
   - name: VPCFlowLogRoleInSpoke
     resource_file: templates/vpc_flowlog_spoke.template
@@ -96,7 +96,7 @@ resources:
         parameter_value: "$[alfred_ssm_/org/core/ManagementAccountId]"
 
       - parameter_key: "ControlTowerMasterRegion"
-        parameter_value: "ap-southeast-2"
+        parameter_value: "<REPLACE ME>"
 
       - parameter_key: "FlowLogBucketName" 
         parameter_value: "$[alfred_ssm_/org/sharedservice/networking/vpcflowlogsbucket]"
@@ -110,10 +110,10 @@ resources:
       - parameter_key: "ComplianceFrequency" # how often to check for tag updates by schedule
         parameter_value: "24"
 
-      - parameter_key: "BaselineCloudTrailStackSetName"
-        parameter_value: "AWSControlTowerBP-BASELINE-CLOUDTRAIL"  # do not change this, used to get all accounts managed by Control Tower.
+      - parameter_key: "BaselineConfigSetName"
+        parameter_value: "AWSControlTowerBP-BASELINE-CONFIG"  # do not change this, used to get all accounts managed by Control Tower.
 
-      - parameter_key: "BaselineCloudTrailStackArn"
+      - parameter_key: "BaselineConfigStackArn"
         parameter_value: "<REPLACE ME>"  # find this from mgmt account in cloudformation stacksets
 
       - parameter_key: "S3LambdaBucket"
@@ -127,6 +127,6 @@ resources:
     deploy_method: stack_set
     deployment_targets:
       accounts:
-        - NetworkingHub
+        - NetworkingHub # This should match your EventBusDestination Account
     regions:
-      - ap-southeast-2
+      - ap-southeast-2 # choose your control tower master region

--- a/cfct/templates/vpc_flowlog_automation_in_hub.template
+++ b/cfct/templates/vpc_flowlog_automation_in_hub.template
@@ -18,11 +18,11 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: FlowLog - Infrastructure at the spoke account for VPC Flow Log automation
 Parameters:
-  BaselineCloudTrailStackSetName:
+  BaselineConfigStackSetName:
     Type: String
     Description: Name of the StackSet to find accounts from. Do not change from default unless you know what you are doing.
     Default: AWSControlTowerBP-BASELINE-CLOUDTRAIL
-  BaselineCloudTrailStackArn:
+  BaselineConfigStackArn:
     Type: String
     Description: ARN of the StackSet to find accounts from.
   OrganizationId:
@@ -143,7 +143,7 @@ Resources:
             Action:
               - cloudformation:ListStackInstances
             Resource:
-              -  !Ref BaselineCloudTrailStackArn
+              -  !Ref BaselineConfigStackArn
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -224,7 +224,7 @@ Resources:
       Code:
         S3Bucket: !Ref S3LambdaBucket
         S3Key: !Ref S3LambdaBucketKey
-      Runtime: "python3.7"
+      Runtime: "python3.12"
       MemorySize: 128
       Timeout: 300
       ReservedConcurrentExecutions: !Ref FlowLogActivatorConcurrency
@@ -235,7 +235,7 @@ Resources:
             s3bucket: !Ref FlowLogBucketName
             master_account: !Ref MgmtAccountId
             master_role: !FindInMap [LambdaVariable,Role, Hub]
-            stackset_name: !Ref BaselineCloudTrailStackSetName
+            stackset_name: !Ref BaselineConfigStackSetName
             stackset_region: !Ref ControlTowerMasterRegion
             tag_keys: !FindInMap [LambdaVariable,Tag, Key]
             tag_all_values: !FindInMap [LambdaVariable,Tag, All]

--- a/cfct/templates/vpc_flowlog_mgmt.template
+++ b/cfct/templates/vpc_flowlog_mgmt.template
@@ -32,7 +32,7 @@ Parameters:
     MinLength: 12
     MaxLength: 12
     Default: 220969071716
-  BaselineCloudTrailStackArn:
+  BaselineConfigStackArn:
     Type: String
     Description: ARN of the StackSet deployed from Control Tower (AWSControlTowerBP-BASELINE-CLOUDTRAIL in mgmt account)
 
@@ -68,7 +68,7 @@ Resources:
             Action:
               - cloudformation:ListStackInstances
             Resource:
-              -  !Ref BaselineCloudTrailStackArn
+              -  !Ref BaselineConfigStackArn
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/cfct/templates/vpc_flowlog_spoke.template
+++ b/cfct/templates/vpc_flowlog_spoke.template
@@ -143,7 +143,7 @@ Resources:
         }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${EventBusDestinationAccount}:event-bus/${EventBusName}
+        - Arn: !Sub arn:aws:events:${ControlTowerMasterRegion}:${EventBusDestinationAccount}:event-bus/${EventBusName}
           Id: "TagCreateUpdateTrigger"
           RoleArn: !GetAtt FlowLogTagSpokeRuleDeliveryRole.Arn
 
@@ -169,4 +169,4 @@ Resources:
               - Effect: Allow
                 Action:
                   - events:PutEvents
-                Resource: !Sub arn:aws:events:${AWS::Region}:${EventBusDestinationAccount}:event-bus/${EventBusName}
+                Resource: !Sub arn:aws:events:${ControlTowerMasterRegion}:${EventBusDestinationAccount}:event-bus/${EventBusName}


### PR DESCRIPTION
Fixes: #26 #25 

Was working with customer. It was unclear what all regions to deploy the automation template or really any of the items. The spoke template would try to send to an event bridge in the networking account as the template was deployed, when I believe the intent was to target the event bus in the Control Tower Primary Region. The rest of the changes are implementing fixes in the issues.

After making these changes I was able to get this to deploy with a Control Tower 3.3




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
