### PR TITLE
Update to Python 3.12 and remove race condition with IAM

### DIFF
--- a/blog/template/ct_vpc_flowlog_master_stack.yml
+++ b/blog/template/ct_vpc_flowlog_master_stack.yml
@@ -118,7 +118,7 @@ Resources:
       Code:
         S3Bucket: !FindInMap [ S3perRegion, !Ref "AWS::Region", NAME ]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "Key", "LifeCycle"]]]
-      Runtime: "python3.7"
+      Runtime: "python3.12"
       MemorySize: 128
       Timeout: 300
       Environment:

--- a/blog/template/ct_vpc_flowlog_stackset.yml
+++ b/blog/template/ct_vpc_flowlog_stackset.yml
@@ -95,14 +95,6 @@ Conditions:
     - !Ref EventBusDestinationAccount
     - !Ref AWS::AccountId
 
-  CreateEventBusOriginRegion: !And
-    - !Equals
-      - !Ref EventBusDestinationAccount
-      - !Ref AWS::AccountId
-    - !Equals 
-      - !Ref MasterRegion
-      - !Ref AWS::Region
-
   NonEventBus: !Not
     - !Equals
       - !Ref EventBusDestinationAccount
@@ -190,10 +182,9 @@ Resources:
             Value: !Ref OrgId
 
   FlowLogActivatorRole:
-    Condition: CreateEventBusOriginRegion
+    Condition: CreateEventBus
     Type: AWS::IAM::Role
     Properties:
-      RoleName: FlowLogActivatorRole
       Description: FlowLog - Role used by Lambda in Hub Account to enable VPC Flow Log
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -244,11 +235,11 @@ Resources:
       FunctionName: !Sub ${AWS::AccountId}-FlowLogActivator
       Description: FlowLog - Function to handle incoming events and activate VPC Flow Log in spoke account
       Handler: "ct_flowlog_activator.lambda_handler"
-      Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/FlowLogActivatorRole'
+      Role: !GetAtt FlowLogActivatorRole.Arn
       Code:
         S3Bucket: !FindInMap [ S3perRegion, !Ref "AWS::Region", NAME ]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "Key", "Activator"]]]
-      Runtime: "python3.7"
+      Runtime: "python3.12"
       MemorySize: 128
       Timeout: 300
       ReservedConcurrentExecutions: 500

--- a/cfct/templates/vpc_flowlog_automation_in_hub.template
+++ b/cfct/templates/vpc_flowlog_automation_in_hub.template
@@ -88,15 +88,6 @@ Parameters:
     Default: 500
     Description: 'The Reserved Concurrent Executions setting for the Flow Log Activator function.'
 
-Conditions:
-
-  CreateEventBusOriginRegion: !And
-    - !Equals
-      - !Ref EventBusDestinationAccount
-      - !Ref AWS::AccountId
-    - !Equals 
-      - !Ref ControlTowerMasterRegion
-      - !Ref AWS::Region
 
 Mappings:
   LambdaVariable:
@@ -168,10 +159,8 @@ Resources:
             Value: !Ref OrganizationId
 
   FlowLogActivatorRole:
-    Condition: CreateEventBusOriginRegion
     Type: AWS::IAM::Role
     Properties:
-      RoleName: FlowLogActivatorRole
       Description: FlowLog - Role used by Lambda in Hub Account to enable VPC Flow Log
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -220,11 +209,11 @@ Resources:
       FunctionName: FlowLogActivator
       Description: FlowLog - Function to handle incoming events and activate VPC Flow Log in spoke account
       Handler: "ct_flowlog_activator.lambda_handler"
-      Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/FlowLogActivatorRole'
+      Role: !GetAtt FlowLogActivatorRole.Arn
       Code:
         S3Bucket: !Ref S3LambdaBucket
         S3Key: !Ref S3LambdaBucketKey
-      Runtime: "python3.7"
+      Runtime: "python3.12"
       MemorySize: 128
       Timeout: 300
       ReservedConcurrentExecutions: !Ref FlowLogActivatorConcurrency


### PR DESCRIPTION
*Issue #, if available:*

* Resolves #26 
* Also resolve #11 about potential race condition where the IAM role is still eventually consistent and not available when Lambda function `FlowLogActivator` is created.

*Description of changes:*

* Update the template (regular + CfCT) to bump Python to v3.12
* Remove the conditions to create one IAM role shared across `FlowLogActivator` lambda in each regions. Instead each `FlowLogActivator` lambda now has it's own dedicated role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
